### PR TITLE
fix: stop merging old log results and remove stale logs completely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.3](https://github.com/ProductPlan/jest-quarantine/compare/v1.1.2...v1.1.3) (2022-04-07)
+
+### Bug Fixes
+
+- stop merging old log results and remove stale logs completely ([cb22e64](https://github.com/ProductPlan/jest-quarantine/commit/cb22e64debe8ae5b428bfa1f5fd545b5303e267e)), closes [#2](https://github.com/ProductPlan/jest-quarantine/issues/2)
+
 ### [1.1.2](https://github.com/ProductPlan/jest-quarantine/compare/v1.1.1...v1.1.2) (2022-04-01)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-quarantine",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "index.js",
   "repository": "https://github.com/ProductPlan/jest-quarantine.git",
   "author": "James Abercrombie <james@productplan.com>",


### PR DESCRIPTION
### SUMMARY:

The original idea behind the log files was to check them into a given repo - however, that's not very practical and the idea was dropped since they are cheap to rebuild. Unfortunately, the merging logic was left in place and resulted in some funky behavior where the logs seemed a run behind the latest.

Additionally, "stale" logs were also being reported on - which means even if you ran against a subset of tests you got reports for any/all of them that had run before - which was not intended.

These changes effectively ignore previous results and remove stale logs ensuring we only see reports for tests we ran and we don't leave any stale junk behind between runs.

Fixes: #2

### TESTING NOTES:
"The first principle is that you must not fool yourself, and you are the easiest person to fool."
- Fill in notes about your test approach -- discussion points:
  - [X] Unit tests