### PR TITLE
chore: drop unused node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "jest": "^27.5.1",
     "lint-staged": "10.5.3",
     "mock-fs": "^5.1.2",
-    "node-fetch": "2.6.1",
     "standard-version": "9.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3485,11 +3485,6 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
### SUMMARY:
A hold over from initial templating `node-fetch` no longer has any dependants and an open dependency issue so time to drop it.

Related issue: https://github.com/ProductPlan/jest-quarantine/security/dependabot/3

### TESTING NOTES:
"The first principle is that you must not fool yourself, and you are the easiest person to fool."
- Fill in notes about your test approach -- discussion points:
  - [X] Unit tests